### PR TITLE
fix: migrate from deprecated nats.EncodedConn to nats.Conn

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,14 @@ GoDoc: [https://pkg.go.dev/github.com/samber/slog-nats](https://pkg.go.dev/githu
 ```go
 type Option struct {
 	// log level (default: debug)
-	Level     slog.Leveler
+	Level slog.Leveler
 
 	// NATS client
+	Connection *nats.Conn
+	Subject    string
+
+	// Deprecated: Use Connection instead. Encoded connections are no longer supported by nats.go.
 	EncodedConnection *nats.EncodedConn
-	Subject           string
 
 	// optional: customize NATS event builder
 	Converter Converter
@@ -175,15 +178,9 @@ func main() {
 		panic(err)
 	}
 
-	ec, err := nats.NewEncodedConn(nc, nats.JSON_ENCODER)
-	if err != nil {
-		panic(err)
-	}
-
-	defer nc.Flush()
 	defer nc.Close()
 
-	logger := slog.New(slognats.Option{Level: slog.LevelDebug, EncodedConnection: ec, Subject: "test"}.NewNATSHandler())
+	logger := slog.New(slognats.Option{Level: slog.LevelDebug, Connection: nc, Subject: "test"}.NewNATSHandler())
 	logger = logger.With("release", "v1.0.0")
 
 	logger.

--- a/example/example.go
+++ b/example/example.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/nats-io/nats.go"
@@ -23,17 +24,14 @@ func main() {
 		panic(err)
 	}
 
-	ec, err := nats.NewEncodedConn(nc, nats.JSON_ENCODER)
-	if err != nil {
-		panic(err)
-	}
-
 	defer func() {
-		nc.Flush()
+		if err := nc.Flush(); err != nil {
+			log.Printf("failed to flush NATS connection: %v", err)
+		}
 		nc.Close()
 	}()
 
-	logger := slog.New(slognats.Option{Level: slog.LevelDebug, EncodedConnection: ec, Subject: "test"}.NewNATSHandler())
+	logger := slog.New(slognats.Option{Level: slog.LevelDebug, Connection: nc, Subject: "test"}.NewNATSHandler())
 	logger = logger.With("release", "v1.0.0")
 
 	logger.

--- a/handler.go
+++ b/handler.go
@@ -2,7 +2,7 @@ package slognats
 
 import (
 	"context"
-
+	"encoding/json"
 	"log/slog"
 
 	"github.com/nats-io/nats.go"
@@ -14,8 +14,11 @@ type Option struct {
 	Level slog.Leveler
 
 	// NATS client
-	EncodedConnection *nats.EncodedConn
-	Subject           string
+	Connection *nats.Conn
+	Subject    string
+
+	// Deprecated: Use Connection instead. Encoded connections are no longer supported by nats.go.
+	EncodedConnection *nats.EncodedConn //nolint:staticcheck
 
 	// optional: customize NATS event builder
 	Converter Converter
@@ -32,7 +35,7 @@ func (o Option) NewNATSHandler() slog.Handler {
 		o.Level = slog.LevelDebug
 	}
 
-	if o.EncodedConnection == nil {
+	if o.Connection == nil && o.EncodedConnection == nil {
 		panic("missing NATS connection")
 	}
 
@@ -71,6 +74,15 @@ func (h *NATSHandler) Handle(ctx context.Context, record slog.Record) error {
 	fromContext := slogcommon.ContextExtractor(ctx, h.option.AttrFromContext)
 	payload := h.option.Converter(h.option.AddSource, h.option.ReplaceAttr, append(h.attrs, fromContext...), h.groups, &record)
 
+	if h.option.Connection != nil {
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		return h.option.Connection.Publish(h.option.Subject, data)
+	}
+
+	//nolint:staticcheck // kept for backward compatibility
 	return h.option.EncodedConnection.Publish(
 		h.option.Subject,
 		payload,


### PR DESCRIPTION
## Summary

Fixes lint failures on main caused by the deprecated `nats.EncodedConn` API and `errcheck` violations.

### Lint errors fixed
- `SA1019`: `nats.EncodedConn` is deprecated
- `SA1019`: `nats.NewEncodedConn` is deprecated  
- `SA1019`: `EncodedConnection.Publish` is deprecated
- `errcheck`: unchecked return value of `nc.Flush()`

### Changes
- Add `Connection *nats.Conn` field to `Option` (preferred)
- Deprecate `EncodedConnection` field (kept for backward compatibility)
- `Handle()` uses `json.Marshal` + `Conn.Publish` when `Connection` is set
- Falls back to `EncodedConnection.Publish` for backward compat
- Updated example to use new `Connection` API
- Updated README

### Backward compatibility

This is a non-breaking change. The old `EncodedConnection` field still works, but users are encouraged to migrate to the new `Connection` field.